### PR TITLE
[Linux/Mac OSX] Diversas correções para compilar no Mac OSX:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,13 @@ if( CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" )
 endif()
 
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SHARED_COMPILER_FLAGS}" )
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
+
+# No Mac OSX, o compilador C não aceita parâmetros do compilador C++
+if( APPLE )
+	set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
+else()
+	set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SHARED_COMPILER_FLAGS}" )
+endif()
 
 unset( SHARED_COMPILER_FLAGS )
 
@@ -139,14 +145,6 @@ elseif( UNIX )
 	set( SHARED_GAME_LINKER_FLAGS
 		${SHARED_GAME_LINKER_FLAGS} "-mfpmath=387 -Werror=return-type -fvisibility=hidden "
 	)
-
-	if( APPLE )
-		set( SHARED_GAME_LINKER_FLAGS
-			${SHARED_GAME_LINKER_FLAGS} "-momit-leaf-frame-pointer -mtune=core2 "
-		)
-	else()
-		#Linux, Cygwin, etc.
-	endif()
 endif()
 
 #Highest warning level and warnings as errors

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -3,7 +3,7 @@
 #
 
 # Prefer game install directory (for shared libs)
-find_library( SDL2_LIB NAMES SDL2.lib libSDL2-2.0.so.0 libSDL2-2.0.0.dylib PATHS ${SDL2_DIR} ${CMAKE_SOURCE_DIR}/external/SDL2/lib NO_DEFAULT_PATH )
+find_library( SDL2_LIB NAMES SDL2.lib libSDL2-2.0.0.dylib libSDL2-2.0.so.0 PATHS ${SDL2_DIR} ${CMAKE_SOURCE_DIR}/external/SDL2/lib NO_DEFAULT_PATH )
 
 include( FindPackageHandleStandardArgs )
 find_package_handle_standard_args( SDL2 DEFAULT_MSG SDL2_LIB )


### PR DESCRIPTION
   - Removido parâmetro do C++ que estava sendo usado no compilador C. Corrige "invalid argument '-std=c++1y' not allowed with 'C/ObjC'" no Mac OSX.
   - Removido parâmetros "-momit-leaf-frame-pointer" e "-mtune=core2" no Mac OSX. Corrige "clang: error: no such file or directory: ';<nome do parametro>'"
   - Invertido a ordem de busca das bibliotecas SDL. Corrige o linker do mesmo no Mac OSX e continua compilando corretamente no Linux.